### PR TITLE
Fix dropdown arrow alignment for RTL in `select.css`

### DIFF
--- a/packages/support/resources/css/components/input/select.css
+++ b/packages/support/resources/css/components/input/select.css
@@ -9,4 +9,9 @@
     &.fi-select-input-has-inline-prefix {
         @apply ps-0;
     }
+    
+    :dir(rtl) & {
+        background-position: left 0.5rem center;
+    }
+    
 }


### PR DESCRIPTION
## Description

This pull request addresses the misalignment of the dropdown arrow icon in Right-to-Left (RTL) layouts by updating the background position for RTL styles. The adjustment ensures that the dropdown arrow icon is visually and functionally correct within RTL mode, enhancing the overall user experience.

This fix is aligned with v3 method in forms.css
![image](https://github.com/user-attachments/assets/3ff83106-71ef-4529-846a-f5e340c88076)

## Visual changes

### Before
In RTL layouts, the dropdown arrow icon was misaligned, appearing in the same position as Left-to-Right (LTR) layouts, which created visual inconsistency and confusion for RTL users.

### After
With the update, the dropdown arrow icon is correctly positioned in RTL layouts. The arrow aligns to the appropriate "start" (left) of the dropdown area, appearing naturally for users whose language flows from Right-to-Left.

**Example Screenshots:**
- **Before** (RTL Misalignment):
![image](https://github.com/user-attachments/assets/1d08cc3d-912d-44c2-902e-de98b0de1e08)

- **After** (Fixed Alignment):
![image](https://github.com/user-attachments/assets/2bf6855e-8c82-45ea-9943-929c14ac00f4)


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
